### PR TITLE
Calendar: scope the event and client feeds to the user's clients

### DIFF
--- a/agent/calendar.php
+++ b/agent/calendar.php
@@ -3,12 +3,12 @@
 // If client_id is in URI then show client Side Bar and client header
 if (isset($_GET['client_id'])) {
     require_once "includes/inc_all_client.php";
-    $client_event_query = "WHERE event_client_id = $client_id";
+    $client_event_query = "WHERE 1 = 1 AND event_client_id = $client_id";
     $client_query = "WHERE 1 = 1 AND client_id = $client_id";
     $client_url = "&client_id=$client_id";
 } else {
     require_once "includes/inc_all.php";
-    $client_event_query = '';
+    $client_event_query = 'WHERE 1 = 1';
     $client_query = 'WHERE 1 = 1';
     $client_url = '';
 }
@@ -134,7 +134,7 @@ require_once "modals/calendar/calendar_event_add.php";
 
 //loop through IDs and create a modal for each
 $sql = mysqli_query($mysqli, "SELECT calendar_color, calendar_id, calendar_name, event_client_id, event_description, event_end,
-    event_id, event_location, event_repeat, event_start, event_title FROM calendar_events LEFT JOIN calendars ON event_calendar_id = calendar_id $client_event_query");
+    event_id, event_location, event_repeat, event_start, event_title FROM calendar_events LEFT JOIN calendars ON event_calendar_id = calendar_id $client_event_query " . clientScopeSql('event_client_id') . "");
 while ($row = mysqli_fetch_assoc($sql)) {
     $event_id = intval($row['event_id']);
     $event_title = escapeHtml($row['event_title']);
@@ -302,7 +302,7 @@ while ($row = mysqli_fetch_assoc($sql)) {
         events: [
             <?php
             $sql = mysqli_query($mysqli, "SELECT calendar_color, calendar_id, calendar_name, event_all_day, event_end, event_id,
-                event_repeat, event_start, event_title FROM calendar_events LEFT JOIN calendars ON event_calendar_id = calendar_id $client_event_query");
+                event_repeat, event_start, event_title FROM calendar_events LEFT JOIN calendars ON event_calendar_id = calendar_id $client_event_query " . clientScopeSql('event_client_id') . "");
 
             // Repeating events are stored as a single row, so the occurrences have to
             // be materialised here - the bundled FullCalendar build has no rrule
@@ -474,7 +474,7 @@ while ($row = mysqli_fetch_assoc($sql)) {
 
             if (!isset($_GET['client_id'])) {
                 //Clients Added
-                $sql = mysqli_query($mysqli, "SELECT client_created_at, client_id, client_name FROM clients");
+                $sql = mysqli_query($mysqli, "SELECT client_created_at, client_id, client_name FROM clients WHERE 1 = 1 " . clientScopeSql('client_id') . "");
                 while ($row = mysqli_fetch_assoc($sql)) {
                     $event_id = intval($row['client_id']);
                     $event_title = json_encode("Client: '" . $row['client_name'] . "' created");


### PR DESCRIPTION
## What

`agent/calendar.php` ignored client restrictions. Three queries returned rows for every client regardless of the user's `user_client_permissions`:

- the `calendar_events` feed that renders the calendar (line 305)
- the `calendar_events` query above it (line 137)
- the Clients Added feed (line 477)

Each now appends `clientScopeSql()` on the resource's own client column.

## Why

A technician restricted to a subset of clients opened the calendar and saw every other client's event titles, descriptions and locations, plus the name of every client on the install.

This reads as an oversight rather than a decision, for three reasons: the invoice, quote, ticket and vendor feeds beside them **in the same file** have always been scoped; the same user is correctly filtered on `clients.php`; and `modals/calendar/calendar_event_edit.php` already calls `enforceClientAccess()` on the single record. Security rule 4 says enforcement has two halves and a page usually needs both — the single-record half was already there, so the list half was the only way through.

## Reproduction

Two clients, one calendar event each, and a Technician allowed only Alpha:

| | Before | After |
|---|---|---|
| Tech's calendar — events | `ALPHA-ONSITE-VISIT`, **`BETA-SECRET-MIGRATION`** | `ALPHA-ONSITE-VISIT` |
| Tech's calendar — clients | Alpha Corp, **Beta Industries** | Alpha Corp |
| Admin's calendar | both | both (unchanged) |
| `?client_id=1` as admin | Alpha only | Alpha only (unchanged) |
| `?client_id=2` as tech | 302 to clients.php | 302 to clients.php (unchanged) |

The same technician was already correctly restricted on `clients.php` throughout, which is the control showing the restriction itself works.

## Notes for review

`clientScopeSql()` returns a fragment beginning with `AND`, so it needs a `WHERE` to hang off. The global branch of `$client_event_query` was an empty string, so both branches now open with `WHERE 1 = 1` — matching what `$client_query` immediately alongside them already did. The Clients Added query had no `WHERE` at all and gets the same treatment.

Scoping is on the events' own `event_client_id`, not on the joined `calendars` table.

Nothing changes for an administrator or an unrestricted user: `clientScopeSql()` returns an empty string for both, and that is what the admin rows above verify.

No schema change, so no migration. `php -l` clean on the changed file and across the tree; `git diff --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5iWwrt2oLV1fX5vek6U4h)_