### PR TITLE
Tickets: move the clock to its own card and put its events in the conversation

### DIFF
--- a/agent/css/ticket.css
+++ b/agent/css/ticket.css
@@ -87,3 +87,51 @@
 #replyTypePicker .btn-check:not(:checked) + .btn:hover {
     background-color: var(--bs-secondary-bg);
 }
+
+/*
+ * Conversation timeline - the rail that clock in / clock out events hang off.
+ *
+ * Only rendered when the clock in / clock out timer is in use and the ticket has
+ * events to show, so a stopwatch install keeps the plain stack of reply cards.
+ * The rail is drawn on the container rather than per item so it runs unbroken
+ * behind the reply cards between two events.
+ */
+.ticket-timeline {
+    position: relative;
+    padding-left: 1.75rem;
+}
+
+.ticket-timeline::before {
+    content: "";
+    position: absolute;
+    left: 0.3rem;
+    top: 0.5rem;
+    bottom: 0.5rem;
+    width: 2px;
+    background-color: var(--bs-border-color);
+}
+
+.ticket-timeline-event {
+    position: relative;
+    padding: 0.4rem 0;
+    font-size: 0.875rem;
+}
+
+.ticket-timeline-event::before {
+    content: "";
+    position: absolute;
+    left: -1.6rem;
+    top: 0.75rem;
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 50%;
+    background-color: var(--bs-secondary);
+}
+
+.ticket-timeline-event.is-in::before {
+    background-color: var(--bs-success);
+}
+
+.ticket-timeline-event.is-out::before {
+    background-color: var(--bs-danger);
+}

--- a/agent/css/ticket.css
+++ b/agent/css/ticket.css
@@ -89,49 +89,13 @@
 }
 
 /*
- * Conversation timeline - the rail that clock in / clock out events hang off.
- *
- * Only rendered when the clock in / clock out timer is in use and the ticket has
- * events to show, so a stopwatch install keeps the plain stack of reply cards.
- * The rail is drawn on the container rather than per item so it runs unbroken
- * behind the reply cards between two events.
+ * Conversation timeline - built on AdminLTE's .timeline component, which supplies
+ * the rail, the icon positions and the card offset. Only the bare event lines need
+ * anything extra: a clock in / clock out is a line rather than a card, so it has no
+ * .timeline-item to inherit the 60px offset that clears the rail.
  */
-.ticket-timeline {
-    position: relative;
-    padding-left: 1.75rem;
-}
-
-.ticket-timeline::before {
-    content: "";
-    position: absolute;
-    left: 0.3rem;
-    top: 0.5rem;
-    bottom: 0.5rem;
-    width: 2px;
-    background-color: var(--bs-border-color);
-}
-
-.ticket-timeline-event {
-    position: relative;
-    padding: 0.4rem 0;
+.timeline > div > .timeline-event {
+    padding: 0.35rem 0;
+    margin-left: 60px;
     font-size: 0.875rem;
-}
-
-.ticket-timeline-event::before {
-    content: "";
-    position: absolute;
-    left: -1.6rem;
-    top: 0.75rem;
-    width: 0.7rem;
-    height: 0.7rem;
-    border-radius: 50%;
-    background-color: var(--bs-secondary);
-}
-
-.ticket-timeline-event.is-in::before {
-    background-color: var(--bs-success);
-}
-
-.ticket-timeline-event.is-out::before {
-    background-color: var(--bs-danger);
 }

--- a/agent/js/ticket_clock.js
+++ b/agent/js/ticket_clock.js
@@ -1,40 +1,34 @@
 (function() {
     document.addEventListener("DOMContentLoaded", function() {
 
-        // The clock itself lives on the server - this only animates the label so a
-        // running clock looks alive. Nothing here decides how long anything ran;
-        // the elapsed time that gets logged is worked out from the stored
-        // timestamps when the user clocks out.
-        var elapsedEl = document.getElementById("ticketClockElapsed");
+        // The clock itself runs on the server - this only animates the label so a
+        // running clock looks alive. Nothing here decides how long anything ran; the
+        // elapsed time that gets logged is worked out from the stored timestamps when
+        // the technician clocks out.
+        //
+        // Each element carries a total the server already worked out, so the browser
+        // only ever adds seconds since page load and never has to agree with the
+        // server about the time of day.
+        var elements = Array.from(document.querySelectorAll(".ticket-timer-elapsed")).map(function(el) {
+            return { el: el, base: parseInt(el.dataset.elapsedSeconds, 10) || 0 };
+        });
 
-        if (!elapsedEl) {
+        if (!elements.length) {
             return;
         }
 
-        // MySQL datetimes have no zone. The server renders them in the install's
-        // timezone and the browser may well be somewhere else, so the difference
-        // is measured against the page load rather than against the wall clock.
-        var startedAt = elapsedEl.dataset.startedAt;
         var pageLoaded = Date.now();
-        var offsetSecs = 0;
-
-        var parsed = Date.parse(startedAt.replace(' ', 'T'));
-        var serverNow = Date.parse(elapsedEl.dataset.serverNow ? elapsedEl.dataset.serverNow.replace(' ', 'T') : '');
-
-        if (!isNaN(parsed) && !isNaN(serverNow)) {
-            offsetSecs = Math.max(0, Math.floor((serverNow - parsed) / 1000));
-        }
 
         function pad(val) {
             return val < 10 ? "0" + val : val;
         }
 
         function tick() {
-            var secs = offsetSecs + Math.floor((Date.now() - pageLoaded) / 1000);
-            var hours = Math.floor(secs / 3600);
-            var minutes = Math.floor((secs % 3600) / 60);
-            var seconds = secs % 60;
-            elapsedEl.textContent = pad(hours) + ":" + pad(minutes) + ":" + pad(seconds);
+            var elapsedSincePageLoad = Math.floor((Date.now() - pageLoaded) / 1000);
+            elements.forEach(function(item) {
+                var secs = item.base + elapsedSincePageLoad;
+                item.el.textContent = pad(Math.floor(secs / 3600)) + ":" + pad(Math.floor((secs % 3600) / 60)) + ":" + pad(secs % 60);
+            });
         }
 
         tick();

--- a/agent/ticket.php
+++ b/agent/ticket.php
@@ -969,13 +969,16 @@ if (isset($_GET['ticket_id'])) {
                 $timer_event_index = 0;
 
                 if ($ticket_timeline) { ?>
-                    <div class="ticket-timeline">
+                    <div class="timeline">
                 <?php }
 
                 if ($ticket_timeline && $ticket_has_running_timer) { ?>
-                    <div class="ticket-timeline-event is-running">
-                        <span class="text-secondary">Running</span> &mdash;
-                        <span class="font-monospace ticket-timer-elapsed" data-elapsed-seconds="<?= $ticket_timer_running_seconds ?>"><?= sprintf("%02d:%02d:%02d", intdiv($ticket_timer_running_seconds, 3600), intdiv($ticket_timer_running_seconds % 3600, 60), $ticket_timer_running_seconds % 60) ?></span>
+                    <div>
+                        <i class="timeline-icon fas fa-hourglass-half bg-secondary text-white"></i>
+                        <div class="timeline-event">
+                            <span class="text-secondary">Running</span> &mdash;
+                            <span class="font-monospace ticket-timer-elapsed" data-elapsed-seconds="<?= $ticket_timer_running_seconds ?>"><?= sprintf("%02d:%02d:%02d", intdiv($ticket_timer_running_seconds, 3600), intdiv($ticket_timer_running_seconds % 3600, 60), $ticket_timer_running_seconds % 60) ?></span>
+                        </div>
                     </div>
                 <?php }
 
@@ -1013,14 +1016,17 @@ if (isset($_GET['ticket_id'])) {
                     // something the client saw, so they get a label, not just a colour
                     if ($ticket_reply_type == 'Internal') {
                         $reply_border = 'dark';
+                        $reply_icon = 'lock';
                         $reply_badge = "<span class='badge bg-dark'><i class='fas fa-fw fa-lock me-1'></i>Internal note</span>";
                         $reply_group = 'internal';
                     } elseif ($ticket_reply_type == 'Client') {
                         $reply_border = 'warning';
+                        $reply_icon = 'reply';
                         $reply_badge = "<span class='badge bg-warning text-dark'><i class='fas fa-fw fa-reply me-1'></i>From client</span>";
                         $reply_group = 'public';
                     } else {
                         $reply_border = 'info';
+                        $reply_icon = 'comment';
                         $reply_badge = "<span class='badge bg-info text-dark'><i class='fas fa-fw fa-comment me-1'></i>Public reply</span>";
                         $reply_group = 'public';
                     }
@@ -1028,7 +1034,11 @@ if (isset($_GET['ticket_id'])) {
                     ?>
 
                     <!-- Begin ticket reply card -->
-                    <div class="card ticket-reply border-start border-<?= $reply_border ?> mb-3" style="border-start-width: 6px !important;" data-reply-group="<?= $reply_group ?>">
+                    <?php if ($ticket_timeline) { ?>
+                        <div>
+                        <i class="timeline-icon fas fa-<?= $reply_icon ?> bg-<?= $reply_border ?> text-white"></i>
+                    <?php } ?>
+                    <div class="card ticket-reply border-start border-<?= $reply_border ?><?php if ($ticket_timeline) { echo " timeline-item"; } else { echo " mb-3"; } ?>" style="border-start-width: 6px !important;" data-reply-group="<?= $reply_group ?>">
                         <div class="card-header px-3 py-2">
                             <div class="d-flex justify-content-between align-items-start w-100">
 
@@ -1106,6 +1116,9 @@ if (isset($_GET['ticket_id'])) {
                             <?php } ?>
                         </div>
                     </div>
+                    <?php if ($ticket_timeline) { ?>
+                        </div>
+                    <?php } ?>
                     <!-- End ticket reply card -->
 
                     <?php
@@ -1770,7 +1783,11 @@ require_once "../includes/footer.php";
             });
 
             document.querySelectorAll('.ticket-reply').forEach(card => {
-                card.hidden = wanted !== 'all' && card.dataset.replyGroup !== wanted;
+                // On the timeline the card sits in a wrapper that also carries its rail
+                // icon, so the wrapper is what hides - otherwise filtering leaves the
+                // icon behind against an empty stretch of rail.
+                const target = card.closest('.timeline > div') || card;
+                target.hidden = wanted !== 'all' && card.dataset.replyGroup !== wanted;
             });
         });
     }

--- a/agent/ticket.php
+++ b/agent/ticket.php
@@ -140,13 +140,18 @@ if (isset($_GET['ticket_id'])) {
         $ticket_timer_minutes = '';
         $ticket_timer_seconds = '';
 
+        $ticket_timer_started_at_display = '';
+        $ticket_timer_elapsed_seconds = 0;
+        $ticket_timer_elapsed_display = '00:00:00';
+
         if ($config_ticket_timer_mode == 1) {
 
-            $timer_row = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT timer_id, timer_started_at FROM ticket_timers WHERE timer_ticket_id = $ticket_id AND timer_user_id = $session_user_id AND timer_stopped_at IS NULL LIMIT 1"));
+            $timer_row = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT timer_id, timer_started_at, TIMESTAMPDIFF(SECOND, timer_started_at, NOW()) AS running_seconds FROM ticket_timers WHERE timer_ticket_id = $ticket_id AND timer_user_id = $session_user_id AND timer_stopped_at IS NULL LIMIT 1"));
 
             if ($timer_row) {
                 $ticket_timer_running_id = intval($timer_row['timer_id']);
                 $ticket_timer_started_at = escapeHtml($timer_row['timer_started_at']);
+                $ticket_timer_started_at_display = date('M d g:ia', strtotime($timer_row['timer_started_at']));
             }
 
             // Segments already clocked but not yet written into a reply. These
@@ -159,6 +164,18 @@ if (isset($_GET['ticket_id'])) {
                 $ticket_timer_minutes = sprintf("%02d", intdiv($ticket_timer_unapplied % 3600, 60));
                 $ticket_timer_seconds = sprintf("%02d", $ticket_timer_unapplied % 60);
             }
+
+            // The card's big figure is whichever number its caption is about: the stint
+            // in progress while the clock runs, and what is banked and waiting to be
+            // logged once it stops. Mixing the two under one label reads as a stint that
+            // has been going far longer than it has.
+            if ($ticket_timer_running_id) {
+                $ticket_timer_elapsed_seconds = intval($timer_row['running_seconds']);
+            } else {
+                $ticket_timer_elapsed_seconds = $ticket_timer_unapplied;
+            }
+
+            $ticket_timer_elapsed_display = sprintf("%02d:%02d:%02d", intdiv($ticket_timer_elapsed_seconds, 3600), intdiv($ticket_timer_elapsed_seconds % 3600, 60), $ticket_timer_elapsed_seconds % 60);
         }
 
         $ticket_assigned_to = intval($ticket['ticket_assigned_to']);
@@ -304,6 +321,54 @@ if (isset($_GET['ticket_id'])) {
             AND ticket_reply_archived_at IS NULL
             ORDER BY ticket_reply_id DESC"
         );
+
+        /*
+         * Clock in / clock out events for the conversation timeline. Each segment is
+         * up to two events - it started, and if it has finished, it stopped - so they
+         * are flattened here and merged into the reply list as it renders.
+         *
+         * Everyone's segments are listed: the point of the timeline is who was on this
+         * ticket and when, which is not a question about the reader.
+         */
+        $ticket_timer_events = [];
+        $ticket_timer_running_seconds = 0;
+        $ticket_has_running_timer = false;
+
+        if ($config_ticket_timer_mode == 1) {
+
+            $sql_timer_events = mysqli_query($mysqli, "SELECT timer_started_at, timer_stopped_at, user_name,
+                TIMESTAMPDIFF(SECOND, timer_started_at, NOW()) AS running_seconds FROM ticket_timers
+                LEFT JOIN users ON timer_user_id = user_id
+                WHERE timer_ticket_id = $ticket_id");
+
+            while ($timer_event_row = mysqli_fetch_assoc($sql_timer_events)) {
+
+                $timer_event_user = escapeHtml($timer_event_row['user_name']);
+
+                if (empty($timer_event_row['timer_stopped_at'])) {
+                    $ticket_has_running_timer = true;
+                    $ticket_timer_running_seconds = max($ticket_timer_running_seconds, intval($timer_event_row['running_seconds']));
+                } else {
+                    $ticket_timer_events[] = [
+                        'at' => $timer_event_row['timer_stopped_at'],
+                        'type' => 'out',
+                        'user' => $timer_event_user
+                    ];
+                }
+
+                $ticket_timer_events[] = [
+                    'at' => $timer_event_row['timer_started_at'],
+                    'type' => 'in',
+                    'user' => $timer_event_user
+                ];
+            }
+
+            // Newest first, matching the reply order the conversation already uses.
+            // The stored format sorts correctly as a string, so no date parsing.
+            usort($ticket_timer_events, function ($a, $b) {
+                return strcmp($b['at'], $a['at']);
+            });
+        }
 
         /*
          * Every attachment on the ticket in one query, split by reply. The page
@@ -852,20 +917,12 @@ if (isset($_GET['ticket_id'])) {
                                                         <input type="text" class="form-control" inputmode="numeric" id="hours" name="hours" placeholder="Hrs" min="0" max="23" pattern="0?[0-9]|1[0-9]|2[0-3]" value="<?= $ticket_timer_hours ?>">
                                                         <input type="text" class="form-control" inputmode="numeric" id="minutes" name="minutes" placeholder="Mins" min="0" max="59" pattern="[0-5]?[0-9]" value="<?= $ticket_timer_minutes ?>">
                                                         <input type="text" class="form-control" inputmode="numeric" id="seconds" name="seconds" placeholder="Secs" min="0" max="59" pattern="[0-5]?[0-9]" value="<?= $ticket_timer_seconds ?>">
-                                                        <?php if ($config_ticket_timer_mode == 1) { ?>
-                                                            <?php if ($ticket_timer_running_id) { ?>
-                                                                <a class="btn btn-danger" href="post.php?stop_ticket_timer=<?= $ticket_timer_running_id ?>&csrf_token=<?= $_SESSION['csrf_token'] ?>" title="Clock out"><i class="fas fa-fw fa-stop me-2"></i>Clock out</a>
-                                                            <?php } else { ?>
-                                                                <a class="btn btn-light" href="post.php?start_ticket_timer=<?= $ticket_id ?>&csrf_token=<?= $_SESSION['csrf_token'] ?>" title="Clock in"><i class="fas fa-fw fa-hourglass-start me-2"></i>Clock in</a>
-                                                            <?php } ?>
-                                                        <?php } else { ?>
+                                                        <?php if ($config_ticket_timer_mode == 0) { ?>
                                                             <button type="button" class="btn btn-light" id="startStopTimer" title="Start / stop timer"><i class="fas fa-play"></i></button>
                                                             <button type="button" class="btn btn-light" id="resetTimer" title="Reset timer"><i class="fas fa-redo-alt"></i></button>
                                                         <?php } ?>
                                                     </div>
-                                                    <?php if ($config_ticket_timer_mode == 1 && $ticket_timer_running_id) { ?>
-                                                        <small class="text-secondary">Clocked in <span class="font-monospace" id="ticketClockElapsed" data-started-at="<?= $ticket_timer_started_at ?>" data-server-now="<?= date('Y-m-d H:i:s') ?>">00:00:00</span> ago<?php if ($ticket_timer_banked) { ?> &middot; <?= $ticket_timer_banked ?> already banked<?php } ?></small>
-                                                    <?php } elseif ($config_ticket_timer_mode == 1 && $ticket_timer_banked) { ?>
+                                                    <?php if ($config_ticket_timer_mode == 1 && $ticket_timer_banked) { ?>
                                                         <small class="text-secondary"><?= $ticket_timer_banked ?> clocked and ready to log</small>
                                                     <?php } ?>
                                                 </div>
@@ -906,6 +963,22 @@ if (isset($_GET['ticket_id'])) {
 
                 <?php
 
+                // The rail only appears where there are clock events to hang off it -
+                // a stopwatch install sees the conversation exactly as before.
+                $ticket_timeline = $config_ticket_timer_mode == 1 && (!empty($ticket_timer_events) || $ticket_has_running_timer);
+                $timer_event_index = 0;
+
+                if ($ticket_timeline) { ?>
+                    <div class="ticket-timeline">
+                <?php }
+
+                if ($ticket_timeline && $ticket_has_running_timer) { ?>
+                    <div class="ticket-timeline-event is-running">
+                        <span class="text-secondary">Running</span> &mdash;
+                        <span class="font-monospace ticket-timer-elapsed" data-elapsed-seconds="<?= $ticket_timer_running_seconds ?>"><?= sprintf("%02d:%02d:%02d", intdiv($ticket_timer_running_seconds, 3600), intdiv($ticket_timer_running_seconds % 3600, 60), $ticket_timer_running_seconds % 60) ?></span>
+                    </div>
+                <?php }
+
                 while ($reply_row = mysqli_fetch_assoc($sql_ticket_replies)) {
                     $ticket_reply_id = intval($reply_row['ticket_reply_id']);
                     $ticket_reply = $purifier->purify($reply_row['ticket_reply']);
@@ -927,6 +1000,13 @@ if (isset($_GET['ticket_id'])) {
                         $user_initials = initials($reply_row['user_name']);
                         $avatar_link = "../uploads/users/$user_id/$user_avatar";
                         $ticket_reply_time_worked = $reply_row['ticket_reply_time_worked'];
+                    }
+
+                    // Anything clocked since this reply belongs above it
+                    while ($ticket_timeline && $timer_event_index < count($ticket_timer_events)
+                        && strcmp($ticket_timer_events[$timer_event_index]['at'], $reply_row['ticket_reply_created_at']) > 0) {
+                        echo ticketTimelineEvent($ticket_timer_events[$timer_event_index]);
+                        $timer_event_index++;
                     }
 
                     // Internal notes are the one thing that must never be mistaken for
@@ -1032,11 +1112,64 @@ if (isset($_GET['ticket_id'])) {
 
                 }
 
+                // Everything older than the last reply - on a ticket with no replies at
+                // all this is the whole list
+                while ($ticket_timeline && $timer_event_index < count($ticket_timer_events)) {
+                    echo ticketTimelineEvent($ticket_timer_events[$timer_event_index]);
+                    $timer_event_index++;
+                }
+
+                if ($ticket_timeline) { ?>
+                    </div>
+                <?php }
+
                 ?>
 
             </div>
 
             <div class="col-lg-3">
+
+                <!-- Timer - clock in / clock out mode only. The stopwatch stays in the
+                     reply composer where it has always been. -->
+                <?php if ($config_ticket_timer_mode == 1 && !$ticket_is_closed) { ?>
+                    <div class="card mb-3">
+                        <div class="card-header px-3 py-2">
+                            <h5 class="card-title mt-1">
+                                <i class="fas fa-fw fa-hourglass-half me-2"></i>Timer
+                            </h5>
+                        </div>
+                        <div class="card-body text-center p-3">
+
+                            <div class="display-6 font-monospace<?php if ($ticket_timer_running_id) { echo " text-success ticket-timer-elapsed"; } else { echo " text-secondary"; } ?>" <?php if ($ticket_timer_running_id) { ?>data-elapsed-seconds="<?= $ticket_timer_elapsed_seconds ?>"<?php } ?>><?= $ticket_timer_elapsed_display ?></div>
+
+                            <div class="small text-secondary mb-3">
+                                <?php if ($ticket_timer_running_id) { ?>
+                                    Clocked in since <?= $ticket_timer_started_at_display ?>
+                                    <?php if ($ticket_timer_banked) { ?>
+                                        <br><?= $ticket_timer_banked ?> already banked
+                                    <?php } ?>
+                                <?php } elseif ($ticket_timer_banked) { ?>
+                                    Clocked and ready to log
+                                <?php } else { ?>
+                                    Not clocked in
+                                <?php } ?>
+                            </div>
+
+                            <?php if ($can_edit_ticket) { ?>
+                                <?php if ($ticket_timer_running_id) { ?>
+                                    <a class="btn btn-danger w-100" href="post.php?stop_ticket_timer=<?= $ticket_timer_running_id ?>&csrf_token=<?= $_SESSION['csrf_token'] ?>">
+                                        <i class="fas fa-fw fa-stop me-2"></i>Clock out
+                                    </a>
+                                <?php } else { ?>
+                                    <a class="btn btn-success w-100" href="post.php?start_ticket_timer=<?= $ticket_id ?>&csrf_token=<?= $_SESSION['csrf_token'] ?>">
+                                        <i class="fas fa-fw fa-play me-2"></i>Clock in
+                                    </a>
+                                <?php } ?>
+                            <?php } ?>
+
+                        </div>
+                    </div>
+                <?php } ?>
 
                 <!-- Tasks -->
                 <?php if (!$ticket_is_resolved || $task_count) { ?>

--- a/functions/ticket_timer.php
+++ b/functions/ticket_timer.php
@@ -74,6 +74,11 @@ function ticketTimerStopRunning($ticket_id) {
 /*
  * One clock in / clock out entry on the ticket conversation timeline.
  *
+ * Built on AdminLTE's timeline component (libs/adminlte): a wrapper div holding a
+ * .timeline-icon, which the theme positions on the rail. A clock event is a line
+ * rather than a card, so it carries .timeline-event instead of .timeline-item -
+ * the card styling would make an event look like something somebody wrote.
+ *
  * Returns markup rather than echoing, matching slaPercentDisplay() and the other
  * display helpers. The event array is built by agent/ticket.php and its user name
  * is already escaped there, where the row is read.
@@ -84,14 +89,19 @@ function ticketTimelineEvent($event) {
 
     if ($event['type'] == 'in') {
         $label = 'Clocked in';
-        $state = 'is-in';
+        $icon = 'play';
+        $colour = 'success';
     } else {
         $label = 'Clocked out';
-        $state = 'is-out';
+        $icon = 'stop';
+        $colour = 'danger';
     }
 
-    return "<div class='ticket-timeline-event $state'>
-        <span class='text-secondary'>$label</span> &mdash; $when
-        <span class='text-secondary'>&middot; {$event['user']}</span>
+    return "<div>
+        <i class='timeline-icon fas fa-$icon bg-$colour text-white'></i>
+        <div class='timeline-event'>
+            <span class='text-secondary'>$label</span> &mdash; $when
+            <span class='text-secondary'>&middot; {$event['user']}</span>
+        </div>
     </div>";
 }

--- a/functions/ticket_timer.php
+++ b/functions/ticket_timer.php
@@ -70,3 +70,28 @@ function ticketTimerStopRunning($ticket_id) {
         WHERE timer_ticket_id = $ticket_id
         AND timer_stopped_at IS NULL");
 }
+
+/*
+ * One clock in / clock out entry on the ticket conversation timeline.
+ *
+ * Returns markup rather than echoing, matching slaPercentDisplay() and the other
+ * display helpers. The event array is built by agent/ticket.php and its user name
+ * is already escaped there, where the row is read.
+ */
+function ticketTimelineEvent($event) {
+
+    $when = date('n/j/Y g:i A', strtotime($event['at']));
+
+    if ($event['type'] == 'in') {
+        $label = 'Clocked in';
+        $state = 'is-in';
+    } else {
+        $label = 'Clocked out';
+        $state = 'is-out';
+    }
+
+    return "<div class='ticket-timeline-event $state'>
+        <span class='text-secondary'>$label</span> &mdash; $when
+        <span class='text-secondary'>&middot; {$event['user']}</span>
+    </div>";
+}


### PR DESCRIPTION
Follow-on to #4, which is already merged. These two commits were pushed to that branch after it merged, where nothing was proposing them — this is the same work on a fresh branch off `develop`.

## Timer card

The clock sat inside the reply composer, so it was only reachable once the composer was open and read as part of writing a reply rather than as the state of the ticket. It is now a card at the top of the ticket sidebar with a single clock in / clock out button.

The card's figure is the stint in progress while the clock runs, and what is banked once it stops, so it always means what its caption says. Showing the sum of both under "clocked in since 10:48pm" read as a stint that had been going two hours when it had been going half an hour.

The Hrs / Mins / Secs fields stay in the composer, because they are what the reply submits. They are still prefilled from whatever is banked.

## Conversation timeline

Clock in and clock out now appear in the conversation, interleaved with the replies by time, built on the vendored AdminLTE `.timeline` component — `.timeline` for the rail, a `.timeline-icon` per entry, `.timeline-item` on the reply cards. The only rule left in `ticket.css` is the 60px offset for a bare clock event, which has no `.timeline-item` to inherit it from.

Each marker is the icon its entry already uses elsewhere on the page: the reply badges' own lock, comment and reply icons in their own colours, play and stop for clock in and out, and the hourglass for the stint in progress.

## Filtering had to move up a level

The conversation filter hid the reply card directly. On the timeline that card sits inside a wrapper which also carries the rail icon, so filtering to internal notes would have left a public reply's icon behind against an empty stretch of rail. The wrapper is what hides now.

Verified in the browser: 8 visible icons with no filter, 7 with one applied, 8 again on returning to All — the icon always goes with its card.

## Verification

Ordering was checked by document position rather than by eye: `running → clocked in 22:48 → reply 21:49 → clocked out 21:44 → clocked in 21:09 → reply 19:59 → clocked out 19:44 → clocked in 18:59`. Strictly descending, with replies genuinely between events.

The rail is only drawn where there are clock events to hang off it, so an install on the stopwatch keeps the plain stack of reply cards and the stopwatch keeps its place in the composer — re-confirmed after these changes: `startStopTimer`, `resetTimer` and `ticket_time_tracking.js` still render, and no timeline, no icons, no timer card.

No schema change, so no migration. `php -l` clean across the tree, `git diff --check` clean, zero PHP errors on the ticket page. `libs/` untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5iWwrt2oLV1fX5vek6U4h

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5iWwrt2oLV1fX5vek6U4h)_