### PR TITLE
Invoices: count the outstanding balance, not the invoice, in the Unpaid total

### DIFF
--- a/agent/invoices.php
+++ b/agent/invoices.php
@@ -52,10 +52,13 @@ $sql_total_cancelled_amount = mysqli_query($mysqli, "SELECT SUM(invoice_amount) 
 $row = mysqli_fetch_assoc($sql_total_cancelled_amount);
 $total_cancelled_amount = floatval($row['total_cancelled_amount']);
 
-$sql_total_partial_amount = mysqli_query($mysqli, "SELECT SUM(invoice_amount) AS total_partial_amount FROM payments, invoices WHERE payment_invoice_id = invoice_id AND invoice_status = 'Partial' $client_query");
+$sql_total_partial_amount = mysqli_query($mysqli, "SELECT SUM(invoice_amount) AS total_partial_amount FROM invoices WHERE invoice_status = 'Partial' $client_query");
 $row = mysqli_fetch_assoc($sql_total_partial_amount);
 $total_partial_amount = floatval($row['total_partial_amount']);
-$total_partial_count = mysqli_num_rows($sql_total_partial_amount);
+
+$sql_total_partial_paid_amount = mysqli_query($mysqli, "SELECT SUM(payment_amount) AS total_partial_paid_amount FROM payments, invoices WHERE payment_invoice_id = invoice_id AND invoice_status = 'Partial' $client_query");
+$row = mysqli_fetch_assoc($sql_total_partial_paid_amount);
+$total_partial_paid_amount = floatval($row['total_partial_paid_amount']);
 
 $sql_total_overdue_partial_amount = mysqli_query($mysqli, "SELECT SUM(payment_amount) AS total_overdue_partial_amount FROM payments, invoices WHERE payment_invoice_id = invoice_id AND invoice_status = 'Partial' AND invoice_due < CURDATE() $client_query");
 $row = mysqli_fetch_assoc($sql_total_overdue_partial_amount);
@@ -66,7 +69,7 @@ $row = mysqli_fetch_assoc($sql_total_overdue_amount);
 $total_overdue_amount = floatval($row['total_overdue_amount']);
 
 $real_overdue_amount = $total_overdue_amount - $total_overdue_partial_amount;
-$total_unpaid_amount = $total_sent_amount + $total_viewed_amount + $total_partial_amount;
+$total_unpaid_amount = $total_sent_amount + $total_viewed_amount + ($total_partial_amount - $total_partial_paid_amount);
 $unpaid_count = $sent_count + $viewed_count + $partial_count;
 
 $overdue_query = '';


### PR DESCRIPTION
## Summary

The Unpaid card on `agent/invoices.php` overstates its figure, and the overstatement **grows every time a client makes a payment**. Present in `itflow-org/itflow` on both `develop` and `master`.

## The line

`agent/invoices.php:55`

```php
SELECT SUM(invoice_amount) FROM payments, invoices
WHERE payment_invoice_id = invoice_id AND invoice_status = 'Partial'
```

Two faults in one statement:

1. It sums `invoice_amount` — the **whole invoice**, not the balance still owed.
2. Joining `payments` repeats the invoice row **once per payment**, so the whole invoice is counted again for every payment received against it.

The join onto `payments` serves no other purpose here — no payment column is read — which is what points to the intent being to net payments off.

## It was a copy/paste slip, and the correct version is four lines below

Both queries were added in the same commit, `988788b7c` (johnnyq, 27 Aug):

```php
// line 55 - sums the wrong column, and the join multiplies it
SUM(invoice_amount) ... FROM payments, invoices ... invoice_status = 'Partial'

// line 60 - same shape, correct column, then subtracted
SUM(payment_amount) ... FROM payments, invoices ... invoice_status = 'Partial' AND invoice_due < CURDATE()
$real_overdue_amount = $total_overdue_amount - $total_overdue_partial_amount;
```

That is exactly why **Overdue is right and Unpaid is wrong**.

This is also the only place in the tree that sums `invoice_amount` across that join — every other site sums `payment_amount`. Isolated defect, not a pattern.

## Reproduced on a clean install, on unmodified upstream code

Checked out `upstream/develop` at `b982dfe2d`, dropped the database, reinstalled from `db.sql` via `scripts/setup_cli.php`. One client, one invoice, all payments created **through ITFlow's own handlers** — no hand-written SQL. ITFlow sets `Partial` itself (`agent/post/payment.php:292`), so this is a state the application produces, not one contrived for the test.

One $1,000 invoice, paid down in instalments:

| payments | actually owed | Unpaid card shows | error |
|---|---|---|---|
| 2 | $600.00 | **$2,000.00** | 3.3× |
| 3 | $400.00 | **$3,000.00** | 7.5× |
| 4 | $200.00 | **$4,000.00** | 20× |
| 5 | $100.00 | **$5,000.00** | 50× |

The more the client pays, the larger the outstanding figure becomes.

The multiplication, visible in the join's own output:

```
payment_id  payment_amount  invoice_amount (counted again per payment row)
1           200.00          1000.00
2           200.00          1000.00
```

```
line 55 as written  -> 2000.00
what it should be   ->  600.00
```

## The fix

Take the partial figure as **two separate sums** — invoice total, less payments against it — so no row is multiplied. Same shape the Overdue card already uses.

On that same install with that same data, changing only this file: **$5,000.00 → $100.00** (invoice $1,000, paid $900).

## Verified

| Case | Expected | After fix |
|---|---|---|
| Two payments on a 1,000 partial | 1,400.00 | 1,400.00 |
| Five payments on the same invoice | 1,300.00 | 1,300.00 |
| Partial invoice with no payment rows (`SUM` is NULL) | 1,800.00 | 1,800.00 |
| No partial invoices at all | 1,800.00 | 1,800.00 |
| Overpayment (1,200 paid on 1,000) | 600.00 | 600.00 |

No regression: Overdue still reads 600.00 on an overdue partial invoice, and client scoping holds — a technician restricted to one client sees 1,400.00 where an administrator sees 11,399.00. The new query carries `$client_query` exactly as its neighbours do.

## Also

Drops `$total_partial_count`, which took `mysqli_num_rows()` of an aggregate query — always 1 — and was never read.

No schema change, so no migration. `php -l` clean across the tree, `git diff --check` clean, zero PHP notices on the page in either the default or `?status=Unpaid` view.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5iWwrt2oLV1fX5vek6U4h